### PR TITLE
Blog grid with SolidJS tag filtering (draft)

### DIFF
--- a/src/components/BlogGrid.tsx
+++ b/src/components/BlogGrid.tsx
@@ -1,0 +1,105 @@
+import { createMemo, createSignal, For } from "solid-js";
+import { format } from "date-fns";
+
+interface Post {
+  id: string;
+  title: string;
+  pubDate: string;
+  heroImage: string;
+  tags: string[];
+}
+
+interface Props {
+  posts: Post[];
+}
+
+export default function BlogGrid(props: Props) {
+  const [selectedTags, setSelectedTags] = createSignal<string[]>([]);
+
+  const allTags = createMemo(() => {
+    const tagSet = new Set<string>();
+    for (const post of props.posts) {
+      for (const tag of post.tags) tagSet.add(tag);
+    }
+    return [...tagSet].sort();
+  });
+
+  const filteredPosts = createMemo(() => {
+    const selected = selectedTags();
+    if (selected.length === 0) return props.posts;
+    return props.posts
+      .map((p) => ({
+        ...p,
+        matchCount: p.tags.filter((t) => selected.includes(t)).length,
+      }))
+      .filter((p) => p.matchCount > 0)
+      .sort((a, b) => b.matchCount - a.matchCount);
+  });
+
+  function toggleTag(tag: string) {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    );
+  }
+
+  return (
+    <div>
+      <div class="flex flex-wrap gap-2 mb-6">
+        <For each={allTags()}>
+          {(tag) => (
+            <button
+              onClick={() => toggleTag(tag)}
+              class={`px-3 py-1 rounded-full text-sm border-2 transition-colors cursor-pointer ${
+                selectedTags().includes(tag)
+                  ? "bg-black text-white"
+                  : "bg-white text-black hover:bg-gray-50"
+              }`}
+            >
+              {tag}
+            </button>
+          )}
+        </For>
+      </div>
+
+      <div class="inline-grid xl:grid-cols-4 lg:grid-cols-3 grid-cols-2 gap-x-4 gap-y-4 mb-4 w-full">
+        <For each={filteredPosts()}>
+          {(post, index) => (
+            <a
+              href={`/blog/${post.id}`}
+              class={`block ${selectedTags().length === 0 && index() === 0 ? "col-span-2" : ""}`}
+            >
+              <div class="flex flex-col rounded border-2 overflow-hidden shadow-lg bg-white h-full">
+                <img
+                  class="block object-cover w-full aspect-3/2"
+                  src={post.heroImage}
+                  alt={post.title}
+                />
+                <div class="px-4 py-3 font-bold text-xl text-center">
+                  {post.title}
+                </div>
+                <div class="px-4 pb-2 text-center text-slate-500 text-sm">
+                  {format(new Date(post.pubDate), "yyyy-MM-dd")}
+                </div>
+                <div class="px-4 pb-4 flex flex-wrap gap-1 justify-center mt-auto">
+                  <For each={post.tags}>
+                    {(tag) => (
+                      <span
+                        class={`px-2 py-0.5 rounded-full text-xs ${
+                          selectedTags().includes(tag)
+                            ? "bg-black text-white"
+                            : "bg-gray-100 text-gray-600"
+                        }`}
+                      >
+                        {tag}
+                      </span>
+                    )}
+                  </For>
+                </div>
+              </div>
+            </a>
+          )}
+        </For>
+      </div>
+    </div>
+  );
+}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -9,6 +9,7 @@ const blog = defineCollection({
     description: z.string(),
     pubDate: z.coerce.date(),
     heroImage: z.string(),
+    tags: z.array(z.string()).default([]),
   }),
 });
 

--- a/src/content/blog/hotw-001-obsidian-archiver-plugin.md
+++ b/src/content/blog/hotw-001-obsidian-archiver-plugin.md
@@ -3,6 +3,7 @@ title: "Hack of the week - Obsidian archiver plugin"
 description: "Experiments with buliding an obsidian plugin"
 pubDate: "Sep 29 2023"
 heroImage: "/blog/hotw-001-obsidian-archiver-plugin/demo_grouped.gif"
+tags: ["Obsidian", "Typescript", "Hack-of-the-week"]
 ---
 
 I use obsidian for note taking and I thought it'd be a good idea to create an archive folder for notes that aren't relevant anymore. Manually moving files to an archive folder was tedious, so I wanted to script it. A simple python script worked but I thought why not try my hand at making a plugin

--- a/src/content/blog/hotw-002-server-driven-mui.md
+++ b/src/content/blog/hotw-002-server-driven-mui.md
@@ -3,6 +3,7 @@ title: "Hack of the week - Server Driven MUI"
 description: "Having a server decide layout of material UI components in a page"
 pubDate: "Dec 3 2023"
 heroImage: "/blog/hotw-002-server-driven-mui/nice-table-component-demo.png"
+tags: ["Typescript", "Frontend", "Hack-of-the-week"]
 ---
 
 I became curious about server-driven UI patterns as a way to improve the iteration cycles of app developers. They're
@@ -45,40 +46,30 @@ A react component representation is made using a createElement method (which is 
 
 ```jsx
 // JSX like this
-<h1>Hack of the week - Server Driven MUI</h1>
+<h1>Hack of the week - Server Driven MUI</h1>;
 
 // becomes
-createElement(
-  "h1",
-  null,
-  "Hack of the week - Server Driven MUI"
-)
+createElement("h1", null, "Hack of the week - Server Driven MUI");
 ```
 
 A functional component can be given to the `createElement` function also, and the children can be a string, undefined, or a list of react elements:
 
 ```jsx
 function FancyTitle({ props, children }) {
-  return <div style={{ fontSize: props.size }}>
-    {children}
-  </div>
+  return <div style={{ fontSize: props.size }}>{children}</div>;
 }
 
 // JSX like this
 <FancyTitle size="5em">
   <h1>Heading</h1>
   <p>text</p>
-</FancyTitle>
+</FancyTitle>;
 
 // becomes
-createElement(
-  FancyTitle,
-  {"size": "5em"},
-  [
-    createElement("h1", null, "Heading"),
-    createElement("p", null, "text")
-  ]
-)
+createElement(FancyTitle, { size: "5em" }, [
+  createElement("h1", null, "Heading"),
+  createElement("p", null, "text"),
+]);
 ```
 
 We can leverage this to render items dynamically from the server. We'll have the server return the name of the
@@ -113,12 +104,13 @@ a page with components based on that json response body
 
 Before I built a python service, I created a mock json response with enough information I'd need to render the above
 table correctly. To render a component, I need:
- * a string html element name, string body, or component class
- * some props
- * a list of children
-This can be done with a simple enough representation model. Something that looked like this (you can see the full tree
-of components represented in json
-[here](https://github.com/thenomadlad/server-driven-mui/blob/main/sdmui-python/app.py#L34)):
+
+- a string html element name, string body, or component class
+- some props
+- a list of children
+  This can be done with a simple enough representation model. Something that looked like this (you can see the full tree
+  of components represented in json
+  [here](https://github.com/thenomadlad/server-driven-mui/blob/main/sdmui-python/app.py#L34)):
 
 ```json
 [
@@ -168,15 +160,15 @@ SDUI_COMPONENTS = {
   Table: Table,
   TableBody: TableBody,
   // ... more component classes
-}
+};
 
 // ...
 
 createElement(
   SDUI_COMPONENTS[sdui_data.component] as FunctionalComponent,
   sdui_piece.props,
-  renderSduiComponent(sdui_piece.children)
-)
+  renderSduiComponent(sdui_piece.children),
+);
 ```
 
 Once I got the above to work, I made a simple python flask server which returns the comopnent tree in json format:
@@ -273,8 +265,8 @@ could be rendered:
 ```tsx
 const SDUI_COMPONENTS = {
   // ... other components
-  NiceTable: NiceTable
-}
+  NiceTable: NiceTable,
+};
 ```
 
 And.. that was it! When I went to the url `localhost:3000/http/localhost:5000/nice_table_demo`, I saw this:
@@ -300,7 +292,7 @@ the system, that a backend system defines the components necessarily means that 
 
 One additional downside to this approach has to do with the dynamic nature of this system, we could introduce security
 issues when dynamically loading modules
-  
+
 ## Next steps
 
 There are some large parts of the common contract that still need to be defined, specifically the language to define

--- a/src/content/blog/my-site-runs-on-astro.md
+++ b/src/content/blog/my-site-runs-on-astro.md
@@ -3,6 +3,7 @@ title: "My site runs on astro"
 description: "I have become an astronaut (the frontend dev kind)"
 pubDate: "Jun 29 2023"
 heroImage: "/blog/my-site-runs-on-astro/placeholder-hero.jpg"
+tags: ["Typescript", "Frontend", "Astro"]
 ---
 
 I've been wanting to create my own website and showcase my work, any dev diaries and blogs on development. I've tried

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,33 +1,23 @@
 ---
 import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
-import Card from "../../components/Card.astro";
+import BlogGrid from "../../components/BlogGrid";
 
-const posts = (await getCollection("blog")).sort(
-  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
-);
+const posts = (await getCollection("blog"))
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+  .map((p) => ({
+    id: p.id,
+    title: p.data.title,
+    pubDate: p.data.pubDate.toISOString(),
+    heroImage: p.data.heroImage,
+    tags: p.data.tags,
+  }));
 ---
 
 <BaseLayout>
   <div class="flex">
-    <div class="m-auto inline-grid gap-y-20 justify-center items-center">
-      <div
-        class="inline-grid xl:grid-cols-4 lg:grid-cols-3 grid-cols-2 gap-x-4 gap-y-4 mb-4"
-      >
-        {
-          posts.map((post) => (
-            <a class="block first:col-span-2" href={`/blog/${post.id}`}>
-              <Card heading={post.data.title} date={post.data.pubDate}>
-                <img
-                  class="block object-cover h-full w-full aspect-3/2"
-                  src={post.data.heroImage}
-                  alt={post.data.title}
-                />
-              </Card>
-            </a>
-          ))
-        }
-      </div>
+    <div class="m-auto w-full">
+      <BlogGrid posts={posts} client:load />
     </div>
   </div>
 </BaseLayout>


### PR DESCRIPTION
Stashing away until there are enough articles for filtering to be useful.

## What's here
- `BlogGrid.tsx` SolidJS island: multiselect OR tag filter, sorted by match count, first post spans 2 cols when unfiltered
- Tags added to frontmatter of existing 3 posts
- `content.config.ts` schema updated with `tags: z.array(z.string()).default([])`

🤖 Generated with [Claude Code](https://claude.com/claude-code)