### PR TITLE
Add format:md script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "astro": "astro",
     "check": "astro check",
     "lint": "eslint src",
-    "prettier:write": "prettier --write . --plugin=prettier-plugin-astro"
+    "prettier:write": "prettier --write . --plugin=prettier-plugin-astro",
+    "format:md": "prettier --write 'src/**/*.md'"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.9",


### PR DESCRIPTION
Adds `pnpm run format:md` which runs prettier over `src/**/*.md` only.

The existing `prettier:write` runs on `.` which churns through `analysis/.venv/` (thousands of files). This scoped alternative is the practical command to use for formatting blog post markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)